### PR TITLE
fix: "sendEvent가 eventId를 받아 on과 emit을 동일한 스코프에서 실행할 수 있도록 수정"

### DIFF
--- a/client/utils/generateEventId.js
+++ b/client/utils/generateEventId.js
@@ -1,0 +1,12 @@
+/**
+ * SendEvent에 사용되는 이벤트 인스턴스 고유ID
+ */
+const eventId = 0;
+
+/**
+ * SendEvent에 사용할 이벤트 인스턴스의 고유ID를 생성하는 함수
+ * @returns {Number} eventId
+ */
+export const generateEventId = () => {
+  return eventId++;
+};

--- a/src/handlers/helper.js
+++ b/src/handlers/helper.js
@@ -45,5 +45,5 @@ export const handleEvent = (io, socket, data) => {
   }
 
   // Response 전달
-  socket.emit('response', { response });
+  socket.emit(`${data.eventId}_response`, { response });
 };


### PR DESCRIPTION
- 고유한 eventId를 생성하는 generateEventId 함수를 client\utils에 추가
- 서버가 socket.emit("response")를 새로운 sendEvent 로직에 따라 처리하도록 수정